### PR TITLE
Added basic homebrew Formula

### DIFF
--- a/Formula/loop.rb
+++ b/Formula/loop.rb
@@ -1,0 +1,18 @@
+class Loop < Formula
+  desc "UNIX's missing `loop` command"
+  homepage "https://github.com/Miserlou/Loop"
+  url "https://github.com/Miserlou/Loop/archive/master.zip"
+  sha256 "ae3faebac27fe4fd1f14de8f348e3df410f0b8fd02deea54ef4abcd1f7e08648"
+  head "https://github.com/Miserlou/Loop.git"
+  version "0.1.0"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--root", prefix
+  end
+
+  test do
+    system "#{bin}/loop", "-V"
+  end
+end


### PR DESCRIPTION
People can install it like this:

```
brew tap miserlou/loop https://github.com/Miserlou/Loop.git
brew install loop --HEAD
```

The version is hardcoded now, to make the formula legal.

If you want it to be added to homebrew-core, you'll have to start making versioned releases.