### PR TITLE
Add functionality to look untill error state or success state

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -61,3 +61,13 @@ args:
         value_name: until_time
         help: Keep going until a future time, ex. "2018-04-20 04:20:00" (Times in UTC.)
         takes_value: true
+    - until_error:
+        short: r
+        long: until-error
+        value_name: until_error
+        help: Keep going until the command exit status is non-zero, or the value given
+        default_value: "any_error"
+    - until_success:
+        short: s
+        long: until-success
+        help: Keep going until the command exit status is 0


### PR DESCRIPTION
This might be a useable implementation of --until-error and --until-success
mentioned in #1.

Until-error allows for an optional parameter to specify the specific exit code waited for.

So, --until-error 0 is basically the same as --until-success.