### PR TITLE
Adds a naive summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Loops in bash are surprisingly complicated and fickle! I wanted a simple and int
  * Iterate over the **standard input**!
     - `$ cat files_to_create.txt | loop 'touch $ITEM'`
 
+ * Get a **summary** of the runs!
+    - `$ loop 'ls' --for-duration 10min --summary`
+
  * ..and **much more!**
 
  And so `loop` was born!
@@ -137,6 +140,18 @@ There's also an `$ACTUALCOUNT`:
     2 1
     4 2
     [ .. ]
+
+You can get a summary of successes and failures (based on exit codes) with `--summary`:
+
+    $ loop 'echo $COUNT' --num 5
+    0
+    1
+    2
+    3
+    4
+    Total runs:  5
+    Successes:   5
+    Failures:    0
 
 ### Timed Loops
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ You can get a summary of successes and failures (based on exit codes) with `--su
     Successes:   5
     Failures:    0
 
+or
+
+    $ loop 'ls -foobarbatz' --num 3
+    ...
+    Total runs:  3
+    Successes:   0
+    Failures:    3 (-1, -1, 1)
+
+
 ### Timed Loops
 
 Loops can be set to timers which accept [humanized times](https://github.com/tailhook/humantime) from the microsecond to the year with `--every`:

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,15 @@ struct Summary {
 impl Summary {
     fn print(self) {
         let total = self.successes + self.failures.len() as u32;
-        let errors = self.failures.into_iter().map(|f| (-(f as i32)).to_string()).collect::<Vec<String>>().join(", ");
+
+        let errors = if self.failures.is_empty() {
+            String::from("0")
+        } else {
+            self.failures.into_iter()
+                .map(|f| (-(f as i32)).to_string())
+                .collect::<Vec<String>>()
+                .join(", ")
+        };
 
         println!("Total runs:\t{}", total);
         println!("Successes:\t{}", self.successes);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use regex::Regex;
 use subprocess::{Exec, ExitStatus, Redirection};
 use structopt::StructOpt;
 
+static UNKONWN_EXIT_CODE: u32 = 99;
+
 fn main() {
 
     // Load the CLI arguments
@@ -114,7 +116,7 @@ fn main() {
             match result.exit_status {
                 ExitStatus::Exited(0)  =>  summary.successes += 1,
                 ExitStatus::Exited(n) => summary.failures.push(n),
-                _ => summary.failures.push(99),
+                _ => summary.failures.push(UNKONWN_EXIT_CODE),
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,10 +257,10 @@ impl Summary {
         let errors = if self.failures.is_empty() {
             String::from("0")
         } else {
-            self.failures.into_iter()
-                .map(|f| (-(f as i32)).to_string())
-                .collect::<Vec<String>>()
-                .join(", ")
+            format!("{} ({})", self.failures.len(), self.failures.into_iter()
+                    .map(|f| (-(f as i32)).to_string())
+                    .collect::<Vec<String>>()
+                    .join(", "))
         };
 
         println!("Total runs:\t{}", total);


### PR DESCRIPTION
This PR adds a very naive summary.

Here is a screenshot where there are no failures: 
<img width="362" alt="screen shot 2018-07-18 at 23 32 32" src="https://user-images.githubusercontent.com/1850188/42911431-e33e7746-8ae2-11e8-9218-962199fca8f5.png">

And here is one showing the 5 `-1` failures in a bad `ls` command:
<img width="464" alt="screen shot 2018-07-19 at 00 03 01" src="https://user-images.githubusercontent.com/1850188/42912402-28999e52-8ae7-11e8-902c-e0782a6e94e1.png">

It solves my use case, but do let me know if you have any feedback 😄 