### PR TITLE
Add an option to show output from only the final execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ humantime = "1.1.1"
 isatty = "0.1.8"
 regex = "1.0.0"
 subprocess = "0.1.12"
+tempfile = "3.0.3"
 
 [[bin]]
 name = "loop"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,12 @@ extern crate humantime;
 extern crate isatty;
 extern crate regex;
 extern crate subprocess;
+extern crate tempfile;
 
 use std::env;
 use std::f64;
-use std::io::{self, BufRead};
+use std::io::prelude::*;
+use std::io::{self, BufRead, SeekFrom};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -50,6 +52,7 @@ fn main() {
 
     let mut has_matched = false;
 
+    let mut tmpfile = tempfile::tempfile().unwrap();
     let mut summary = Summary { successes: 0, failures: Vec::new() };
 
     let counter = Counter { start: opt.offset, end: num, step_by: opt.count_by};
@@ -68,14 +71,24 @@ fn main() {
         }
 
         // Main executor
+        tmpfile.seek(SeekFrom::Start(0)).ok();
+        tmpfile.set_len(0).ok();
         let result = Exec::shell(&opt.input)
-            .stdout(Redirection::Pipe)
+            .stdout(Redirection::File(tmpfile.try_clone().unwrap()))
             .stderr(Redirection::Merge)
             .capture().unwrap();
 
         // Print the results
-        for line in result.stdout_str().lines() {
-            println!("{}", line);
+        let mut stdout = String::new();
+        tmpfile.seek(SeekFrom::Start(0)).ok();
+        tmpfile.read_to_string(&mut stdout).ok();
+        for line in stdout.lines() {
+            // --only-last
+            // If we only want output from the last execution,
+            // defer printing until later
+            if !opt.only_last {
+                println!("{}", line);
+            }
 
             // --until-contains
             // We defer loop breaking until the entire result is printed.
@@ -149,6 +162,15 @@ fn main() {
         }
     }
 
+    if opt.only_last {
+        let mut stdout = String::new();
+        tmpfile.seek(SeekFrom::Start(0)).ok();
+        tmpfile.read_to_string(&mut stdout).ok();
+        for line in stdout.lines() {
+            println!("{}", line);
+        }
+    }
+
     if opt.summary {
         summary.print()
     }
@@ -206,6 +228,10 @@ struct Opt {
     /// Keep going until the command exit status is non-zero, or the value given
     #[structopt(short = "s", long = "until-success")]
     until_success: bool,
+
+    /// Only print the output of the last execution of the command
+    #[structopt(short = "l", long = "only-last")]
+    only_last: bool,
 
     /// Read from standard input
     #[structopt(short = "i", long = "stdin")]


### PR DESCRIPTION
Here's a potential fix for #24.
Instead of capturing the output via pipe, it's now written to a file and the file is printed after the last output.
There's probably some refactoring that could be done to make things a bit nicer but I thought I'd get some feedback on the approach.