### PR TITLE
Specify bin.path in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ subprocess = "0.1.12"
 
 [[bin]]
 name = "loop"
+path = "src/main.rs"


### PR DESCRIPTION
I was seeing the warning below when building.
This just sets the path as suggested.

```
warning: path `/home/mmior/apps/Loop/src/main.rs` was erroneously implicitly accepted for binary `loop`,
please set bin.path in Cargo.toml
```