### PR TITLE
Fix bug when command has no output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,25 +109,25 @@ fn main() {
                     has_matched = true;
                 }
             }
+        }
 
-            // --until-error
-            if let Some(error_code) = &opt.until_error {
-                match error_code {
-                    ErrorCode::Any => if !result.exit_status.success() {
+        // --until-error
+        if let Some(error_code) = &opt.until_error {
+            match error_code {
+                ErrorCode::Any => if !result.exit_status.success() {
+                    has_matched = true;
+                },
+                ErrorCode::Code(code) =>  {
+                    if result.exit_status == ExitStatus::Exited(*code) {
                         has_matched = true;
-                    },
-                    ErrorCode::Code(code) =>  {
-                        if result.exit_status == ExitStatus::Exited(*code) {
-                            has_matched = true;
-                        }
                     }
                 }
             }
+        }
 
-            // --until-success
-            if opt.until_success && result.exit_status.success() {
-                    has_matched = true;
-            }
+        // --until-success
+        if opt.until_success && result.exit_status.success() {
+                has_matched = true;
         }
 
         if opt.summary {


### PR DESCRIPTION
When I was playing around I was testing with the `true` command and noticed that the exit status tests were inside the loop over output lines.
This just moves them outside of the loop so they only run once (which we want anyway) and they will run even if the command has no output.