### PR TITLE
Align Cargo.lock with Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "loop-rs"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
NixOS relies on `cargo build --frozen` to ensure reproducible builds. This can only work if `Cargo.toml` and `Cargo.lock` agree on package version.
This pull-request re-aligns `Cargo.lock` with respect to `loop-rs` version.