### PR TITLE
Bugfix '--until-changes' and add '--until-stagnates' flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "loop-rs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Loops in bash are surprisingly complicated and fickle! I wanted a simple and int
  * Loop **until output matches** a condition!
    - `$ loop --until-contains 200 -- ./get_response_code.sh --site mysite.biz`
 
- * Loop **until output changes between invocations**!
+ * Loop **until output changes or stays the same between invocations**!
    - `$ loop --until-changes date +%s`
+   - `$ loop --until-stagnates date +%s`
 
  * Loop **until a certain time**!
    - `$ loop './poke_server' --for-duration 8h`
@@ -224,6 +225,13 @@ Or until a certain date/time with `--until-time`:
 
     $ loop --only-last --every 1s --until-changes -- 'date +%s' 
     1548884135
+    $
+
+`loop` can iterate until the output stays the same with `--until-stagnates`. This would be useful, for instance,
+for monitoring with `du` until a download or copy finishes:
+
+    $ loop --every 1s --until-stagnates -- 'du -bs .' 
+    236861997       .
     $
 
 Or until a program succeeds with `--until-success`:

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,10 +166,19 @@ fn main() {
             }
         }
 
-        // --until-changes
         if let Some(ref previous_stdout) = previous_stdout {
-            if *previous_stdout != stdout {
-                break;
+            // --until-changes
+            if opt.until_changes {
+                if *previous_stdout != stdout {
+                    break;
+                }
+            }
+
+            // --until-stagnates
+            if opt.until_stagnates {
+                if *previous_stdout == stdout {
+                    break;
+                }
             }
         } else {
             previous_stdout = Some(stdout);
@@ -232,6 +241,10 @@ struct Opt {
     /// Keep going until the output changes
     #[structopt(short = "C", long = "until-changes")]
     until_changes: bool,
+
+    /// Keep going until the output changes
+    #[structopt(short = "S", long = "until-stagnates")]
+    until_stagnates: bool,
 
     /// Keep going until the output matches this regular expression
     #[structopt(short = "m", long = "until-match", parse(try_from_str = "Regex::new"))]


### PR DESCRIPTION
The `--until-changes` flag was being triggered on every invocation,
so now it's only triggered if the flag is passed.

The `--until-stagnates` flag is the foil to `--until-changes`, which
will exit if the output *stops* changing.

Add `--until-stagnates` to the README