### PR TITLE
Add flag to return error code on duration timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Loops in bash are surprisingly complicated and fickle! I wanted a simple and int
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Installation](#installation)
   - [Linux](#linux)
   - [OSX](#osx)
@@ -58,6 +59,7 @@ Loops in bash are surprisingly complicated and fickle! I wanted a simple and int
   - [Waiting for a file to be created](#waiting-for-a-file-to-be-created)
   - [Create a backup for all files in a directory](#create-a-backup-for-all-files-in-a-directory)
   - [Keep trying a failing script until it passes, up to 5 times](#keep-trying-a-failing-script-until-it-passes-up-to-5-times)
+  - [Keep trying a failing script until timeout](#keep-trying-a-failing-script-until-timeout)
   - [Comparison with GNU Parallel](#comparison-with-gnu-parallel)
   - [More examples](#more-examples)
 - [Contributing](#contributing)
@@ -362,6 +364,16 @@ With `loop`, it's a simple one liner:
     loop './do_thing.sh' --every 15s --until-success --num 5 
 
 Which will do the thing every 15 seconds until it succeeds, for a maximum of five times.
+
+### Keep trying a failing script until timeout
+
+If dealing with a command or script that occasionally fails in a CI environment, you may want to try for a given amount of time before giving up and failing the build.
+
+With `loop` you can do that with:
+
+    loop './do_thing.sh' --every 5s --until-success --for-duration 180s --duration-error
+
+Which will do the thing every 5 seconds until it succeeds or until the duration is met. If the duration is met, it will give the same non-zero return as the `timeout` command 124.
 
 ### Comparison with GNU Parallel
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::env;
 use std::f64;
 use std::io::prelude::*;
 use std::io::{self, BufRead, SeekFrom};
+use std::process;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -20,6 +21,9 @@ use structopt::StructOpt;
 
 static UNKONWN_EXIT_CODE: u32 = 99;
 
+// same exit code as use of `timeout` shell command
+static TIMEOUT_EXIT_CODE: i32 = 124;
+
 fn main() {
 
     // Load the CLI arguments
@@ -29,6 +33,8 @@ fn main() {
         .value_of("count_by")
         .map(precision_of)
         .unwrap_or(0);
+
+    let mut exit_status = 0;
 
     // Time
     let program_start = Instant::now();
@@ -161,6 +167,9 @@ fn main() {
         if let Some(duration) = opt.for_duration {
             let since = Instant::now().duration_since(program_start);
             if since >= duration {
+                if opt.error_duration {
+                    exit_status = TIMEOUT_EXIT_CODE
+                }
                 break;
             }
         }
@@ -211,6 +220,7 @@ fn main() {
     if opt.summary {
         summary.print()
     }
+    process::exit(exit_status);
 }
 
 #[derive(StructOpt, Debug)]
@@ -281,6 +291,10 @@ struct Opt {
     /// Read from standard input
     #[structopt(short = "i", long = "stdin")]
     stdin: bool,
+
+    /// Exit with timeout error code on duration
+    #[structopt(short = "D", long = "error-duration")]
+    error_duration: bool,
 
     /// Provide a summary
     #[structopt(long = "summary")]


### PR DESCRIPTION
This pull request adds an additional flag to loop specifically to exit with an error status if the duration is reached. The use for this is as follows:


In a CI task, I have misbehaving task `foo` that occasional fails with an error code due to an interim fail. So I decided to wrap it with loop like so:

```
loop --until-success foo
```

The problem is changes to our code and the environment could cause `foo` to fail for real forever. So I initially ended up using the duration flag like so:

```
loop --until-success -d 180s foo
```

The problem was if `foo` could never succeed, the exit code of loop was still zero so the work around was to drop the duration flag and use the `timeout` command like so:

```
timeout 180s loop --until-success foo
```

This commit enables an error code directly from loop so it cuts out the need for `timeout` which is also not natively on some environments like OSX. With the new flag, the same result above is achieved like so:


```
loop --until-success -d 180s -D foo
```
