### PR TITLE
Move --for-duration and --until-time logic to fix extra iteration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,23 @@ fn main() {
             env::set_var("ITEM", item);
         }
 
+        // Finish if we're over our duration
+        if let Some(duration) = opt.for_duration {
+            let since = Instant::now().duration_since(program_start);
+            if since >= duration {
+                break;
+            }
+        }
+
+        // Finish if our time until has passed
+        // In this location, the loop will execute at least once,
+        // even if the start time is beyond the until time.
+        if let Some(until_time) = opt.until_time {
+            if SystemTime::now().duration_since(until_time).is_ok() {
+                break;
+            }
+        }
+
         // Main executor
         tmpfile.seek(SeekFrom::Start(0)).ok();
         tmpfile.set_len(0).ok();
@@ -157,22 +174,7 @@ fn main() {
             break;
         }
 
-        // Finish if we're over our duration
-        if let Some(duration) = opt.for_duration {
-            let since = Instant::now().duration_since(program_start);
-            if since >= duration {
-                break;
-            }
-        }
 
-        // Finish if our time until has passed
-        // In this location, the loop will execute at least once,
-        // even if the start time is beyond the until time.
-        if let Some(until_time) = opt.until_time {
-            if SystemTime::now().duration_since(until_time).is_ok() {
-                break;
-            }
-        }
 
         if let Some(ref previous_stdout) = previous_stdout {
             // --until-changes


### PR DESCRIPTION
Fixes #47 by moving the check for --for-duration and --until-time before the execution of the command rather than after it.