### PR TITLE
Fix documentation of until-error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -272,7 +272,7 @@ struct Opt {
     #[structopt(short = "t", long = "until-time", parse(try_from_str = "parse_rfc3339_weak"))]
     until_time: Option<SystemTime>,
 
-    /// Keep going until the command exit status is non-zero, or the value given
+    /// Keep going until the command exit status is the value given
     #[structopt(short = "r", long = "until-error", parse(from_str = "get_error_code"))]
     until_error: Option<ErrorCode>,
 


### PR DESCRIPTION
I have found that the documentation declares argument of --until-error as optional, but the argument expects the specific value of error code to stop on. (For any error --until-fail is used, am I right?)