### PR TITLE
Fix negative error codes in summary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ or
     [ .. ]
     Total runs:  3
     Successes:   0
-    Failures:    3 (-1, -1, -1)
+    Failures:    3 (1, 1, 1)
 
 If you only want the output of the last result, you can use `--only-last`:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,8 +362,8 @@ impl Summary {
         let errors = if self.failures.is_empty() {
             String::from("0")
         } else {
-            format!("{} ({})", self.failures.len(), self.failures.into_iter()
-                    .map(|f| (-(f as i32)).to_string())
+            format!("{} ({})", self.failures.len(), self.failures.as_slice().into_iter()
+                    .map(|f| ((*f as u32)).to_string())
                     .collect::<Vec<String>>()
                     .join(", "))
         };


### PR DESCRIPTION
Fix the summary to report error codes of executed command as a positive number, not negative one.

Described in the issue #64